### PR TITLE
PLAT-309 Switch to our own Node images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10
+FROM quay.io/vital/node:lts
 
 # Install common dependencies
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \


### PR DESCRIPTION
## Why
A new Node.js vulnerability was published. Our growing number of distinct Dockerfiles makes patching harder.

## How
Change base image for Node.js Dockerfiles to use Vital's self-managed ones.

#### Before Merging
- [x] All relevant technical documentation has been created/updated
- [x] All relevant compliance documentation has been created/updated
- [x] Configuration changes have been documented and communicated to the team
- [x] This affects developer experience (i.e IDEs, stack), and it has been tested and communicated to the team
